### PR TITLE
Add ./run test option

### DIFF
--- a/local-development/the-run-script.md
+++ b/local-development/the-run-script.md
@@ -25,6 +25,7 @@ The basic options are:
 ./run serve  # Start the Django server, optionally watching for changes
 ./run build  # Build the CSS
 ./run watch  # Watch and build the CSS whenever Sass changes
+./run test   # Check code syntax and run unit tests
 ./run clean  # Remove created files and docker containers
 ```
 


### PR DESCRIPTION
`./run test` should be part of the standard interface, and it should be documented to encourage people to implement it fully.