### PR TITLE
Change ports around

### DIFF
--- a/local-development/ports.md
+++ b/local-development/ports.md
@@ -13,7 +13,7 @@ This is so that team members can easily run multiple projects at the same time w
 | 8001 | [www.ubuntu.com](https://github.com/canonical-websites/www.ubuntu.com) |
 | 8002 | [www.canonical.com](https://github.com/canonical-websites/www.canonical.com) |
 | 8003 | [partners.ubuntu.com](https://github.com/canonical-websites/partners.ubuntu.com) |
-| 8004 | ~[snapcraft.io](https://github.com/canonical-websites/snapcraft.io)~ AVAILABLE |
+| 8004 | [snapcraft.io](https://github.com/canonical-websites/snapcraft.io) |
 | 8005 | [conjure-up.io](https://github.com/canonical-websites/conjure-up.io) |
 | 8006 | [maas.io](https://github.com/canonical-websites/maas.io) |
 | 8007 | [docs.ubuntu.com](https://github.com/canonical-websites/docs.ubuntu.com) |
@@ -33,9 +33,9 @@ This is so that team members can easily run multiple projects at the same time w
 | 8021 | RESERVED: Possible use [by iTunes Radio streams](https://support.apple.com/en-za/HT202944) |
 | 8022 | [snapcraft.io](https://github.com/canonical-websites/snapcraft.io/) |
 | 8023 | [insights.ubuntu.com](https://github.com/canonical-websites/insights.ubuntu.com/) |
-| 8024 | [phone-docs](https://github.com/canonical-docs/phone-docs/) |
-| 8025 | [usn.ubuntu.com](https://launchpad.net/usn.ubuntu.com) |
+| 8024 | [usn.ubuntu.com](https://launchpad.net/usn.ubuntu.com) |
 | 8101 | [vanilla-framework](https://github.com/vanilla-framework/vanilla-framework) |
+| 8201 | [phone-docs](https://github.com/canonical-docs/phone-docs/) |
 
 ## Why use a fixed port
 


### PR DESCRIPTION
Similarly to how I started using `81**` ports for Vanilla-framework (and other non-website projects) I think it makes sense to use a new range, `82**`, for docs repositories that are sub-paths under `docs.ubuntu.com`. Thus, phone-docs is now `8201`.

I also think snapcraft.io should use the port it used to, to try to remain a bit more consistent and not leave a hole so low in the range.