### PR TITLE
Add snappy-docs port

### DIFF
--- a/local-development/ports.md
+++ b/local-development/ports.md
@@ -8,33 +8,34 @@ This is so that team members can easily run multiple projects at the same time w
 
 ## Defaults
 
-| Port | Project |
-| ---- | ------- |
-| 8001 | [www.ubuntu.com](https://github.com/canonical-websites/www.ubuntu.com) |
-| 8002 | [www.canonical.com](https://github.com/canonical-websites/www.canonical.com) |
-| 8003 | [partners.ubuntu.com](https://github.com/canonical-websites/partners.ubuntu.com) |
-| 8004 | [snapcraft.io](https://github.com/canonical-websites/snapcraft.io) |
-| 8005 | [conjure-up.io](https://github.com/canonical-websites/conjure-up.io) |
-| 8006 | [maas.io](https://github.com/canonical-websites/maas.io) |
-| 8007 | [docs.ubuntu.com](https://github.com/canonical-websites/docs.ubuntu.com) |
+| Port | Project                                                                                           |
+| ---- | -------                                                                                           |
+| 8001 | [www.ubuntu.com](https://github.com/canonical-websites/www.ubuntu.com)                            |
+| 8002 | [www.canonical.com](https://github.com/canonical-websites/www.canonical.com)                      |
+| 8003 | [partners.ubuntu.com](https://github.com/canonical-websites/partners.ubuntu.com)                  |
+| 8004 | [snapcraft.io](https://github.com/canonical-websites/snapcraft.io)                                |
+| 8005 | [conjure-up.io](https://github.com/canonical-websites/conjure-up.io)                              |
+| 8006 | [maas.io](https://github.com/canonical-websites/maas.io)                                          |
+| 8007 | [docs.ubuntu.com](https://github.com/canonical-websites/docs.ubuntu.com)                          |
 | 8008 | RESERVED: [Alternative HTTP port](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers) |
-| 8009 | [cloud-init.io](https://github.com/canonical-websites/cloud-init.io) |
-| 8010 | [cn.ubuntu.com](https://github.com/canonical-websites/cn.ubuntu.com) |
-| 8011 | [design.ubuntu.com](https://github.com/canonical-websites/design.ubuntu.com) |
-| 8012 | [jp.ubuntu.com](https://github.com/canonical-websites/jp.ubuntu.com) |
-| 8013 | [tour.ubuntu.com](https://github.com/canonical-websites/tour.ubuntu.com) |
-| 8014 | [vanillaframework.io](https://github.com/canonical-websites/vanillaframework.io/) |
-| 8015 | [developer.ubuntu.com](https://github.com/canonical-websites/developer.ubuntu.com/) |
-| 8016 | [tutorials.ubuntu.com](https://github.com/canonical-websites/tutorials.ubuntu.com/) |
-| 8017 | [assets.ubuntu.com](https://github.com/canonical-websites/assets.ubuntu.com/) |
-| 8018 | [manager.assets.ubuntu.com](https://github.com/canonical-websites/manager.assets.ubuntu.com/) |
-| 8019 | [community.ubuntu.com](https://github.com/canonical-websites/community.ubuntu.com/) |
-| 8020 | [usn.ubuntu.com](https://github.com/canonical-websites/usn.ubuntu.com/) |
-| 8021 | RESERVED: Possible use [by iTunes Radio streams](https://support.apple.com/en-za/HT202944) |
-| 8022 | [usn.ubuntu.com](https://launchpad.net/usn.ubuntu.com) |
-| 8023 | [insights.ubuntu.com](https://github.com/canonical-websites/insights.ubuntu.com/) |
-| 8101 | [vanilla-framework](https://github.com/vanilla-framework/vanilla-framework) |
-| 8201 | [phone-docs](https://github.com/canonical-docs/phone-docs/) |
+| 8009 | [cloud-init.io](https://github.com/canonical-websites/cloud-init.io)                              |
+| 8010 | [cn.ubuntu.com](https://github.com/canonical-websites/cn.ubuntu.com)                              |
+| 8011 | [design.ubuntu.com](https://github.com/canonical-websites/design.ubuntu.com)                      |
+| 8012 | [jp.ubuntu.com](https://github.com/canonical-websites/jp.ubuntu.com)                              |
+| 8013 | [tour.ubuntu.com](https://github.com/canonical-websites/tour.ubuntu.com)                          |
+| 8014 | [vanillaframework.io](https://github.com/canonical-websites/vanillaframework.io/)                 |
+| 8015 | [developer.ubuntu.com](https://github.com/canonical-websites/developer.ubuntu.com/)               |
+| 8016 | [tutorials.ubuntu.com](https://github.com/canonical-websites/tutorials.ubuntu.com/)               |
+| 8017 | [assets.ubuntu.com](https://github.com/canonical-websites/assets.ubuntu.com/)                     |
+| 8018 | [manager.assets.ubuntu.com](https://github.com/canonical-websites/manager.assets.ubuntu.com/)     |
+| 8019 | [community.ubuntu.com](https://github.com/canonical-websites/community.ubuntu.com/)               |
+| 8020 | [usn.ubuntu.com](https://github.com/canonical-websites/usn.ubuntu.com/)                           |
+| 8021 | RESERVED: Possible use [by iTunes Radio streams](https://support.apple.com/en-za/HT202944)        |
+| 8022 | [usn.ubuntu.com](https://launchpad.net/usn.ubuntu.com)                                            |
+| 8023 | [insights.ubuntu.com](https://github.com/canonical-websites/insights.ubuntu.com/)                 |
+| 8101 | [vanilla-framework](https://github.com/vanilla-framework/vanilla-framework)                       |
+| 8201 | [phone-docs](https://github.com/canonical-docs/phone-docs/)                                       |
+| 8202 | [snappy-docs](https://github.com/canonical-docs/snappy-docs)                                      |
 
 ## Why use a fixed port
 


### PR DESCRIPTION
Add snappy-docs port: 8202.
To merge once this is merged: https://github.com/canonical-docs/snappy-docs/pull/181