### PR TITLE
Describes some labels; removes “blocked” duplication

### DIFF
--- a/project-management/zenhub.md
+++ b/project-management/zenhub.md
@@ -33,7 +33,7 @@ Current squad boards:
 - There should be one issue per person in the `In Progress` pipeline.
 - Issues should have one assignee at any one time. If an issue requires multiple people at different stages it should be handed over and the assignee changed at the appropriate time. When reassigned, issues should be moved back into the `Current Iteration` pipeline.
 - Issues that are part of an epic should have an estimate based on [the fibonacci estimation guide](https://github.com/canonical-webteam/practices/blob/master/project-management/fibonacci-estimation-guide.md).
-- If for some reason you move to a different issue before completing your current issue, that issue should be moved to the `Current Iteration` pipeline or labelled as `blocked`.
+- If for some reason you move to a different issue before completing your current issue, that issue should be labelled as “blocked”.
 - Issues should have a description if the title isn't obvious.
 - Issues do not need to be part of an epic, but most should.
 
@@ -57,7 +57,7 @@ At the end of an iteration these should be either closed (if all issues are comp
 
 ### Current Iteration
 
-Issues waiting to be picked up in the current iteration. These are either issues that are yet to be started, have been reassigned or are on hold, but not blocked.
+Issues waiting to be picked up in the current iteration. These are either issues that are yet to be started, have been reassigned or are on hold.
 
 ### In Progress
 
@@ -65,7 +65,7 @@ Issues being actively worked on.
 
 Only one issue per person in the squad should be here. As much as we'd like, we can't work on 5 things at once.
 
-If you're waiting for something/ someone to continue work on an issue, move it to the `Blocked` pipeline.
+If you're waiting for something/ someone to continue work on an issue, label it as “blocked”.
 
 If you need to move on to something with a higher priority move any issue you're assigned but not working on back to `Current Iteration`.
 
@@ -76,19 +76,3 @@ Any issue that is deemed code/ UX/ design complete but requires a review or QA.
 ### Closed
 
 Anything that is complete. The final resting place for issues and epics.
-
-## Labels
-
-### blocked
-
-The purpose of marking an issue `blocked` is to alert managers that unblocking it requires their help. Don’t mark it as blocked if, for example, it just needs a meeting to discuss it; that’s something you can arrange yourself.
-
-An issue may be blocked in any unclosed Pipeline: for example, a “Triaged” / “Current Iteration” issue might be blocked if it can’t be started until another issue is closed, or a “Review/QA” issue might be blocked if a required reviewer is on leave. All blocked issues should have a comment explaining why they’re blocked.
-
-### good first issue
-
-Lets potential contributors know that [the issue would be a good one to start with](https://help.github.com/articles/helping-new-contributors-find-your-project-with-labels/). For example, a typo or grammar error.
-
-### help wanted
-
-Alerts contributors that the assigned person (or if there is none, the team as a whole) would prefer outside help in fixing the problem.

--- a/project-management/zenhub.md
+++ b/project-management/zenhub.md
@@ -15,7 +15,7 @@ Current squad boards:
 
 ## Iterations
 
-- Iterations are two weeks. They start on a Monday and finishing on a Friday.
+- Iterations are two weeks. They start on a Monday and finish on a Friday.
 - Each iteration should be a milestone in ZenHub in the format `Iteration [Iteration number] - [endyear]-[endmonth]-[endday]`.
 
  For example `Iteration 9 - 2017-11-17` followed by `Iteration 10 - 2017-12-01`.
@@ -33,7 +33,7 @@ Current squad boards:
 - There should be one issue per person in the `In Progress` pipeline.
 - Issues should have one assignee at any one time. If an issue requires multiple people at different stages it should be handed over and the assignee changed at the appropriate time. When reassigned, issues should be moved back into the `Current Iteration` pipeline.
 - Issues that are part of an epic should have an estimate based on [the fibonacci estimation guide](https://github.com/canonical-webteam/practices/blob/master/project-management/fibonacci-estimation-guide.md).
-- If for some reason you move to a different issue before completing your current issue, that issue should be moved in to either the `Current Iteration` or `Blocked` pipelines.
+- If for some reason you move to a different issue before completing your current issue, that issue should be moved to the `Current Iteration` pipeline or labelled as `blocked`.
 - Issues should have a description if the title isn't obvious.
 - Issues do not need to be part of an epic, but most should.
 
@@ -49,7 +49,7 @@ Where issues are born. This is a general bucket of all the issues that have been
 
 Issues that are scoped and ready to be picked up at some point in a future iteration/ if there's time left at the end of an iteration.
 
-It's of upmost importance that triaged issues are prioritised.
+It's of utmost importance that triaged issues are prioritised.
 
 ### Iteration Epics
 
@@ -69,10 +69,6 @@ If you're waiting for something/ someone to continue work on an issue, move it t
 
 If you need to move on to something with a higher priority move any issue you're assigned but not working on back to `Current Iteration`.
 
-### Blocked
-
-Issues that are blocked for any reason. All blocked issues should have a comment explaining why they're blocked.
-
 ### Review/ QA
 
 Any issue that is deemed code/ UX/ design complete but requires a review or QA.
@@ -80,3 +76,19 @@ Any issue that is deemed code/ UX/ design complete but requires a review or QA.
 ### Closed
 
 Anything that is complete. The final resting place for issues and epics.
+
+## Labels
+
+### blocked
+
+The purpose of marking an issue `blocked` is to alert managers that unblocking it requires their help. Don’t mark it as blocked if, for example, it just needs a meeting to discuss it; that’s something you can arrange yourself.
+
+An issue may be blocked in any unclosed Pipeline: for example, a “Triaged” / “Current Iteration” issue might be blocked if it can’t be started until another issue is closed, or a “Review/QA” issue might be blocked if a required reviewer is on leave. All blocked issues should have a comment explaining why they’re blocked.
+
+### good first issue
+
+Lets potential contributors know that [the issue would be a good one to start with](https://help.github.com/articles/helping-new-contributors-find-your-project-with-labels/). For example, a typo or grammar error.
+
+### help wanted
+
+Alerts contributors that the assigned person (or if there is none, the team as a whole) would prefer outside help in fixing the problem.

--- a/workflow/labels.md
+++ b/workflow/labels.md
@@ -37,7 +37,7 @@ Each review label has 3 steps:
 
 | Label   | Description                                                                            |
 | ----    | ---                                                                                    |
-| Blocked | The issue is block by another issue (put it in the description)                        |
+| Blocked | Alerts managers that unblocking it requires their help. Any blocked issue should have a comment explaining why it’s blocked. Don’t mark it as blocked if, for example, it just needs a meeting to discuss it; that’s something you can arrange yourself. An issue may be blocked in any unclosed Pipeline. |
 | Doing   | Actually working on the issue                                                          |
 | Triaged | A team member has reviewed this issue, agreed that it is valid and assigned a priority |
 
@@ -49,3 +49,5 @@ Each review label has 3 steps:
 | Enhancement | This issue improves the behavior, or adds new features |
 | Maintenance | Update to documentation or dependencies                |
 | Question    | To ask a question about something on the project       |
+| good first issue | Lets potential contributors know that [the issue would be a good one to start with](https://help.github.com/articles/helping-new-contributors-find-your-project-with-labels/). For example, a typo or grammar error. |
+| help wanted | Alerts contributors that the assigned person (or if there is none, the team as a whole) would prefer outside help in fixing the problem. |

--- a/workflow/labels.md
+++ b/workflow/labels.md
@@ -37,7 +37,7 @@ Each review label has 3 steps:
 
 | Label   | Description                                                                            |
 | ----    | ---                                                                                    |
-| Blocked | Alerts managers that unblocking it requires their help. Any blocked issue should have a comment explaining why it’s blocked. Don’t mark it as blocked if, for example, it just needs a meeting to discuss it; that’s something you can arrange yourself. An issue may be blocked in any unclosed Pipeline. |
+| Blocked | Alerts managers that unblocking it requires their help. Any blocked issue should have a comment explaining what help you need. |
 | Doing   | Actually working on the issue                                                          |
 | Triaged | A team member has reviewed this issue, agreed that it is valid and assigned a priority |
 


### PR DESCRIPTION
Adds a “Labels” section alongside the “Pipelines” section, describing a few potentially-misused labels.

Removes the “Blocked” pipeline. It’s redundant for “blocked” to be both a pipeline and a label. It works better as a label, because an issue can understandably be blocked whether it is Untriaged, Triaged, a Current Iteration task, In Progress, or in Review/QA.

Fixes a couple of typos.