### PR TITLE
Add contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,35 @@
-Web team practices
-===
+# Web team practices
 
 A collection of documents that describe best practices for Canonical web team.
 
+## Contents
+
+<!--
+  This table of contents is edited manually.
+  Please update it whenever you add, remove or move a document,
+  and check and update it whenever you get the opportunity.
+-->
+
+- [coding](coding): Style guides and practices for writing code
+  - [browser-support](coding/browser-support.md): The browsers we officially support in our CSS and JavaScript
+  - [html](coding/html.md): Code style standards for HTML
+  - [js](coding/js.md): Code style standards for JavaScript
+  - [stylesheets](coding/stylesheets.md): Code style standards for CSS and Sass
+- [content](content): Practices and recommendations for content
+  - [copy-reviews](content/copy-reviews.md): A checklist for reviewing written content
+- [design](design): Practices and recommendations for design
+  - [vanilla-design-specs](design/vanilla-design-specs.md): When to include when writing a design spec for a Vanilla pattern
+- [foosball](foosball.md): Basic rules to achieve maximum enjoyment while playing of The Great Game
+- [local-development](local-development): Guides and information about running our applications locally
+  - [ports](local-development/ports.md): The local ports used when running our applications locally
+  - [the-run-script](local-development/the-run-script.md): How to run easily run our applications locally using the `./run` script
+- [project-management](project-management): Practices for managing projects within our squads
+  - [fibonacci-estimation-guide](project-management/fibonacci-estimation-guide.md): Guidelines for using points to estimate tasks
+  - [stand-ups](project-management/stand-ups.md): How to run stand-ups in team squads
+  - [zenhub](project-management/zenhub.md): How to use Zenhub in team squads
+- [workflow](workflow): How to work on our GitHub projects and deploy them to Kubernetes
+  - [deploy](workflow/deploy.md): How to deploy a website to production (on Kubernetes)
+  - [github](workflow/github.md): How to contribute to our GitHub projects
+  - [labels](workflow/labels.md): The standard labels used in our GitHub projects
+- [CONTRIBUTING](CONTRIBUTING.md): How to contribute to this practices repository itsemf
+- [README](README.md): About this practices repository (this document)


### PR DESCRIPTION
Right now, the documents in this repo aren't listed anywhere - so I'm adding them to the README.

I know this might get out-of-date, and is only visible at the root of the project etc. etc. but it's better than nothing.

In the future hopefully someone might turn this repo into a proper Jekyll site which will then be hosted with GitHub pages, but for now let's just do this.