### PR TITLE
Add QA steps page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ A collection of documents that describe best practices for Canonical web team.
   - [deploy](workflow/deploy.md): How to deploy a website to production (on Kubernetes)
   - [github](workflow/github.md): How to contribute to our GitHub projects
   - [labels](workflow/labels.md): The standard labels used in our GitHub projects
+  - [qa-steps](workflow/qa-steps.md): Recommendations for common QA steps when reviewing PRs
 - [CONTRIBUTING](CONTRIBUTING.md): How to contribute to this practices repository itsemf
 - [README](README.md): About this practices repository (this document)

--- a/workflow/qa-steps.md
+++ b/workflow/qa-steps.md
@@ -1,0 +1,34 @@
+# QA steps
+
+In this section you will find a list of steps to take when reviewing PRs, in order to catch unforeseen regressions.
+
+## Adding content
+
+- If adding a new page to a site, check that it has been added to the navigation, sitemap and breadcrumbs (where applicable).
+- Check that the new content's copy matches the relevant copydoc.
+
+## Removing a page
+
+- When removing a page, check that it has been removed from the navigation, sitemap and breadcrumbs (where applicable).
+- Ensure that redirects are in place for deprecated urls.
+
+## Navigation
+
+- Check that clicking a navigation link takes you to the right place.
+- If applicable, check that the hover/active state on a navigation link still works.
+
+## Search
+
+- If the site has search functionality, check that searching works properly and you are given relevant results.
+
+## Forms
+
+- If the page you are QAing contains a form, fill it out and check that it still submits. Also, fill it out incorrectly and check that validation still works.
+
+## Browser testing
+
+- Check that the changes look correct on Chrome, Firefox and IE/Edge (see [Browser support](/coding/browser-support.md)).
+
+## Responsiveness
+
+- Check that the changes look correct on mobile, tablet and desktop sizes.


### PR DESCRIPTION
## Done

- Added a page on QA steps to go through, regardless of what the PR does (see [dev catch-up](https://github.com/ubuntudesign/meeting-notes/issues/279) about this). We could link this to a repo's PR template.

## QA

- Check that the QA steps are reasonable
- Add anything you think is important

## Issues

Fixes #66 