### PR TITLE
Guidelines for naming PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A collection of documents that describe best practices for Canonical web team.
   - [stylesheets](coding/stylesheets.md): Code style standards for CSS and Sass
 - [content](content): Practices and recommendations for content
   - [copy-reviews](content/copy-reviews.md): A checklist for reviewing written content
+  - [filenames](content/filenames.md): Filename recommendations for files linked from websites
 - [design](design): Practices and recommendations for design
   - [vanilla-design-specs](design/vanilla-design-specs.md): When to include when writing a design spec for a Vanilla pattern
 - [foosball](foosball.md): Basic rules to achieve maximum enjoyment while playing of The Great Game

--- a/content/filenames.md
+++ b/content/filenames.md
@@ -1,0 +1,18 @@
+# Filenames
+
+We should carefully consider the filenames of files that we link to from our websites. This helps to accurately describe the file's contents in URLs and if users choose to download the files.
+
+## Documents
+
+Documents (e.g. PDFs) linked from websites should follow this format:
+
+```
+canonical-{topic}-{year}-{month}-{day}.{ext}
+```
+
+Keep the "topic" succinct, and use only lower-case letters. For example:
+
+```
+canonical-openstack-delivery-2017-08-06.pdf
+```
+


### PR DESCRIPTION
Brief guidelines for naming PDFs linked to from www.ubuntu.com &c.

Related (private):

- [Spreadsheet of resources linked from www.ubuntu.com](https://docs.google.com/spreadsheets/d/1OMMPxruNqQpS9LSnYYLPD_1iOFlG353ygIh4Y1cFbHE/edit#gid=1478927560)
- [Comment in 'consulting - "Ubuntu OpenStack consulting packages from Canonical"'](https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit?disco=AAAAB-9XKxM)