### PR TITLE
Add code review document

### DIFF
--- a/coding/review.md
+++ b/coding/review.md
@@ -9,6 +9,6 @@
 ### Approval with suggestions for trivial changes
 In some circumstances, if a branch requires a small number of trivial changes you may approve the branch with the caveat that issues you've identified are resolved or considered, rather than marking the branch *needs fixing* (lp) or *request changes* (gh). These changes should be in the category of minor adjustments to file structure, fixing typos, renamings, small css tweaks etc.
 
-If you are the branch author, it is your responsbility to ensure you have addressed these suggestions before merging your branch.
+If you are the branch author, it is your responsibility to ensure you have addressed these suggestions before merging your branch.
 
 Typically if you have co-workers available to you in your timezone, you should seek an additional review if possible.

--- a/coding/review.md
+++ b/coding/review.md
@@ -7,4 +7,4 @@
 ## Etiquette
 Take care not to block landings for branches that only need minor changes.
 
-If a branch requires a small number of changes, favour approving the branch with a cavaet that the issues you've identified are resolved, rather than *needs fixing*[launchpad] or *request changes*[github]. Marking a branch *needs fixing* should be reserved for genuinely broken code, when the author has proposed the wrong solution, or when the code still requires considerable work to be production ready.
+If a branch requires a small number of changes, favour approving the branch with a caveat that the issues you've identified are resolved, rather than *needs fixing*[launchpad] or *request changes*[github]. Marking a branch *needs fixing* should be reserved for genuinely broken code, when the author has proposed the wrong solution, or when the code still requires considerable work to be production ready.

--- a/coding/review.md
+++ b/coding/review.md
@@ -1,0 +1,10 @@
+# Code Review
+
+## Suggestions for Effective Review
+
+[tbd]
+
+## Etiquette
+Take care not to block landings for branches that only need minor changes.
+
+If a branch requires a small number of changes, favour approving the branch with a cavaet that the issues you've identified are resolved, rather than *needs fixing*[launchpad] or *request changes*[github]. Marking a branch *needs fixing* should be reserved for genuinely broken code, when the author has proposed the wrong solution, or when the code still requires considerable work to be production ready.

--- a/coding/review.md
+++ b/coding/review.md
@@ -5,6 +5,8 @@
 [tbd]
 
 ## Etiquette
-Take care not to block landings for branches that only need minor changes.
 
-If a branch requires a small number of changes, favour approving the branch with a caveat that the issues you've identified are resolved, rather than *needs fixing*[launchpad] or *request changes*[github]. Marking a branch *needs fixing* should be reserved for genuinely broken code, when the author has proposed the wrong solution, or when the code still requires considerable work to be production ready.
+### Approval with suggestions for trivial changes
+In some circumstances, if a branch requires a small number of trivial changes you may approve the branch with the caveat that issues you've identified are resolved or considered, rather than marking the branch *needs fixing* (lp) or *request changes* (gh). These changes should be in the category of minor adjustments to file structure, fixing typos, renamings, small css tweaks etc.
+
+Typically if you have co-workers available to you in your timezone, you should seek an additional review if possible.

--- a/coding/review.md
+++ b/coding/review.md
@@ -3,8 +3,8 @@
 ## Etiquette
 
 ### Approval with suggestions for trivial changes
-In some circumstances, if a branch requires a small number of trivial changes you may approve the branch with the caveat that issues you've identified are resolved or considered, rather than marking the branch *needs fixing* (lp) or *request changes* (gh). These changes should be in the category of minor adjustments to file structure, fixing typos, renamings, small css tweaks etc.
+Reviewers may consider approving a branch with the caveat that issues they've identified are resolved or considered, rather than marking the branch *needs fixing* on Launchpad or *request changes* on GitHub.
 
-If you are the branch author, it is your responsibility to ensure you have addressed these suggestions before merging your branch.
+They may only do this when a branch requires a small number of trivial changes (e.g. moving files, fixing typos, renaming variables, small CSS tweaks), and they have reason to expect that they may block progress by not being available for a second review – e.g. because of different timezones.
 
-Typically if you have co-workers available to you in your timezone, you should seek an additional review if possible.
+It is the branch author's responsibility to ensure they have addressed these suggestions before merging their branch. They still should seek an additional review following their changes wherever possible.

--- a/coding/review.md
+++ b/coding/review.md
@@ -1,9 +1,5 @@
 # Code Review
 
-## Suggestions for Effective Review
-
-[tbd]
-
 ## Etiquette
 
 ### Approval with suggestions for trivial changes

--- a/coding/review.md
+++ b/coding/review.md
@@ -9,4 +9,6 @@
 ### Approval with suggestions for trivial changes
 In some circumstances, if a branch requires a small number of trivial changes you may approve the branch with the caveat that issues you've identified are resolved or considered, rather than marking the branch *needs fixing* (lp) or *request changes* (gh). These changes should be in the category of minor adjustments to file structure, fixing typos, renamings, small css tweaks etc.
 
+If you are the branch author, it is your responsbility to ensure you have addressed these suggestions before merging your branch.
+
 Typically if you have co-workers available to you in your timezone, you should seek an additional review if possible.


### PR DESCRIPTION
Add an initial document for code review practices, with some guidelines around etiquette (as discussed in the dev catchup).

I've also added a heading for *Suggestions for Effective Review*, which perhaps we should discuss as a group.