### PR TITLE
Removes code tag form navigation

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -42,7 +42,7 @@
           <ul class="p-navigation__links">
             <li class="p-navigation__link"><a href="/practices/">Home</a></li>
             <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices" class="p-link--external">GitHub repo</a></li>
-            <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices/blob/master/CONTRIBUTING.md" class="p-link--external">Contribute</a></li>
+            <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices/blob/master/CONTRIBUTING.md" class="p-link--external">How to contribute</a></li>
           </ul>
         </nav>
       </header>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -42,7 +42,7 @@
           <ul class="p-navigation__links">
             <li class="p-navigation__link"><a href="/practices/">Home</a></li>
             <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices" class="p-link--external">GitHub repo</a></li>
-            <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices/blob/master/CONTRIBUTING.md" class="p-link--external"><code>CONTRIBUTING.md</code></a></li>
+            <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices/blob/master/CONTRIBUTING.md" class="p-link--external">Contribute</a></li>
           </ul>
         </nav>
       </header>
@@ -130,7 +130,7 @@
           </script>
         </div>
       </aside>
-  
+
       <main class="p-content" id="main-content">
         <div class="p-strip is-shallow">
           <div class="p-content__row">


### PR DESCRIPTION
As much as I understand dev centric `CONTRIBUTING.md` it seems that `<code>` in main nav for some mysterious CSS reason doesn't work well making weird border show up under other elements.

<img width="595" alt="screen shot 2018-11-20 at 15 43 23" src="https://user-images.githubusercontent.com/83575/48781460-5a7e7f80-ecdc-11e8-8b68-23030057b7a9.png">

This fixes that (by removing `<code>`).