### PR TITLE
Suggest using create-react-app for bootstrapping

### DIFF
--- a/coding/react.md
+++ b/coding/react.md
@@ -4,10 +4,10 @@ layout: base
 
 # React coding standards
 
-This document outlines our standards for writing React applications.
+This document outlines our standards for writing React applications and components.
 
-## Starting a new Project
-We recommend [create-react-app](https://github.com/facebook/create-react-app) for bootstrapping a new project, and avoid ejecting as long as feasible.
+## Starting a new React Project
+When starting a new react application, we recommend [create-react-app](https://github.com/facebook/create-react-app) for bootstrapping the project. Avoid [ejecting](https://facebook.github.io/create-react-app/docs/available-scripts#npm-run-eject) as long as feasible to make updating dependencies easier.
 
 ### Preferred libraries
 All projects should generally use the following:

--- a/coding/react.md
+++ b/coding/react.md
@@ -10,11 +10,16 @@ This document outlines our standards for writing React applications.
 We recommend [create-react-app](https://github.com/facebook/create-react-app) for bootstrapping a new project, and avoid ejecting as long as feasible.
 
 ### Preferred libraries
-* routing - [react-router](https://github.com/ReactTraining/react-router)
-* app state management - [redux](https://redux.js.org)
+All projects should generally use the following:
+
 * component testing - [enzyme](https://github.com/airbnb/enzyme)
 * code formatting - [prettier](https://prettier.io) - We realise that not everyone will agree on the choices that Prettier makes, however feel consistency is ultimately more valuable. As has been said in the golang community, "gofmt's style is no one's favorite, yet gofmt is everyone's favorite".
 * linting - [eslint & airbnb](https://www.npmjs.com/package/eslint-config-airbnb)
+
+If you require routing, or state management:
+
+* routing - [react-router](https://github.com/ReactTraining/react-router)
+* app state management - [redux](https://redux.js.org)
 
 If you'd like introduce a new library, or feel we should replace one of the above, please make a PR to start a discussion.
 

--- a/coding/react.md
+++ b/coding/react.md
@@ -12,9 +12,10 @@ When starting a new react application, we recommend [create-react-app](https://g
 ### Preferred libraries
 All projects should generally use the following:
 
+* unittest framework - [jest](https://jestjs.io)
 * component testing - [enzyme](https://github.com/airbnb/enzyme)
-* code formatting - [prettier](https://prettier.io) - We realise that not everyone will agree on the choices that Prettier makes, however feel consistency is ultimately more valuable. As has been said in the golang community, "gofmt's style is no one's favorite, yet gofmt is everyone's favorite".
-* linting - [eslint & airbnb](https://www.npmjs.com/package/eslint-config-airbnb)
+
+Refer to [code-formatting](code-formatting.md) for recommended tools for linting and formatting.
 
 If you require routing, or state management:
 

--- a/coding/react.md
+++ b/coding/react.md
@@ -6,13 +6,23 @@ layout: base
 
 This document outlines our standards for writing React applications.
 
-## Starter Project
+## Starting a new Project
+We recommend [create-react-app](https://github.com/facebook/create-react-app) for bootstrapping a new project, and avoid ejecting as long as feasible.
 
-[canonical-webteam/react-starter](https://github.com/canonical-webteam/react-starter) provides a codified
-example of our standards for react projects (Prettier, AirBnB style).
+### Preferred libraries
+* routing - [react-router](https://github.com/ReactTraining/react-router)
+* app state management - [redux](https://redux.js.org)
+* component testing - [enzyme](https://github.com/airbnb/enzyme)
+* code formatting - [prettier](https://prettier.io) - We realise that not everyone will agree on the choices that Prettier makes, however feel consistency is ultimately more valuable. As has been said in the golang community, "gofmt's style is no one's favorite, yet gofmt is everyone's favorite".
+* linting - [eslint & airbnb](https://www.npmjs.com/package/eslint-config-airbnb)
 
-As much as possible, this project should reflect our standards for React applications. Please make pull requests
-to this project if you feel something should change.
+If you'd like introduce a new library, or feel we should replace one of the above, please make a PR to start a discussion.
+
+### Reference projects
+[CRBS-UI](https://git.launchpad.net/~crbs/crbs/+git/crbs-ui/tree/), while under active development, probably best reflects our standards for react projects currently.
+
+[canonical-webteam/react-starter](https://github.com/canonical-webteam/react-starter) was created to provide a codified
+example of our standards for react projects (Prettier, AirBnB style), and while potentially still a useful reference, may not accurately reflect some of the choices we've made in real-world projects.
 
 ## File Naming Conventions
 

--- a/coding/react.md
+++ b/coding/react.md
@@ -21,6 +21,8 @@ If you'd like introduce a new library, or feel we should replace one of the abov
 ### Reference projects
 [CRBS-UI](https://git.launchpad.net/~crbs/crbs/+git/crbs-ui/tree/), while under active development, probably best reflects our standards for react projects currently.
 
+[build.snapcraft.io](https://github.com/canonical-websites/build.snapcraft.io) - a bit dated, but first fully React centred project in our webteam. Our first use or React, server-side rendering, Redux, Enzyme, etc. While it doesn't fully follow our current standards it may be a good place to check how some of these libraries were used.
+
 [canonical-webteam/react-starter](https://github.com/canonical-webteam/react-starter) was created to provide a codified
 example of our standards for react projects (Prettier, AirBnB style), and while potentially still a useful reference, may not accurately reflect some of the choices we've made in real-world projects.
 


### PR DESCRIPTION
* New react projects should bootstrap from CRA, rather than using canonical-webteam/react-starter.
* Enumerate preferred libraries.
* Suggest CRBS-UI and canonical-webteam/react-starter as useful references, with caveats.