### PR TITLE
Use the logo and title as a home link

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -27,10 +27,10 @@
       <header id="navigation" class="p-navigation">
         <div class="p-navigation__banner">
           <div class="p-navigation__logo">
-            <a class="p-navigation__link" href="https://canonical-webteam.github.io/practices">
+            <a class="p-navigation__link" href="/practices/">
               <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="Canonical">
+              <h4 style="padding: 0.5rem 1rem; margin-bottom: 0">Web and design team practices</h4>
             </a>
-            <h4 style="padding: 0.5rem 1rem; margin-bottom: 0">Web and design team practices</h4>
           </div>
           <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
           <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
@@ -40,7 +40,6 @@
             <a href="#main-content">Jump to main content</a>
           </span>
           <ul class="p-navigation__links">
-            <li class="p-navigation__link"><a href="/practices/">Home</a></li>
             <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices" class="p-link--external">GitHub repo</a></li>
             <li class="p-navigation__link"><a href="https://github.com/canonical-webteam/practices/blob/master/CONTRIBUTING.md" class="p-link--external">How to contribute</a></li>
           </ul>


### PR DESCRIPTION
And remove the "home" link, since this is the pattern we use on
other sites.

Fixes https://github.com/canonical-webteam/practices/issues/111

QA
--

`jekyll serve` and check the site