### PR TITLE
Adds document for python coding standards

### DIFF
--- a/coding/python.md
+++ b/coding/python.md
@@ -1,0 +1,20 @@
+---
+layout: base
+---
+
+# Python code standards
+
+This document outlines the rules for writing Python code across all our Projects.
+
+## Code style and formatting
+
+All Code should be written in accordance with [PEP 8](https://pep8.org/).
+To correctly format all your code please use [black](https://github.com/ambv/black). Since it differs in a small way from the standard **PEP8** make sure to pass `--line-length 79` when using it. The reason for black to do this is outlined [here](https://github.com/ambv/black#line-length).
+
+## Testing
+
+All logic should be tested. If you add something new to the Codebase make sure that you add sufficient testing to ensure longterm maintainability of our projects.
+
+## Documentation
+
+Document your functions with docstrings in accordance with [PEP 257](https://www.python.org/dev/peps/pep-0257/).

--- a/coding/python.md
+++ b/coding/python.md
@@ -8,13 +8,13 @@ This document outlines the rules for writing Python code across all our Projects
 
 ## Code style and formatting
 
-All Code should be written in accordance with [PEP 8](https://pep8.org/).
-To correctly format all your code please use [black](https://github.com/ambv/black). Since it differs in a small way from the standard **PEP8** make sure to pass `--line-length 79` when using it. The reason for black to do this is outlined [here](https://github.com/ambv/black#line-length).
+All code must conform to [PEP 8](https://pep8.org/) and be formatted with [black](https://github.com/ambv/black) using the option `--line-length 79`.
+Any pull requests that do no conform to this should be rejected by the CI.
 
 ## Testing
 
-All logic should be tested. If you add something new to the Codebase make sure that you add sufficient testing to ensure longterm maintainability of our projects.
+Although tests are lacking on many of our existing projects, writing tests is strongly encouraged. Please write tests for any new code if at all possible, and any efforts to improve test coverage on any project would be greatly appreciated.
 
 ## Documentation
 
-Document your functions with docstrings in accordance with [PEP 257](https://www.python.org/dev/peps/pep-0257/).
+You should document your functions with docstrings in accordance with [PEP 257](https://www.python.org/dev/peps/pep-0257/).

--- a/coding/python.md
+++ b/coding/python.md
@@ -9,6 +9,7 @@ This document outlines the rules for writing Python code across all our Projects
 ## Code style and formatting
 
 All code must conform to [PEP 8](https://pep8.org/) and be formatted with [black](https://github.com/ambv/black) using the option `--line-length 79`.
+
 Project should be configured to block merging on pull requests that do not conform to these standards.
 
 ## Testing

--- a/coding/python.md
+++ b/coding/python.md
@@ -9,7 +9,7 @@ This document outlines the rules for writing Python code across all our Projects
 ## Code style and formatting
 
 All code must conform to [PEP 8](https://pep8.org/) and be formatted with [black](https://github.com/ambv/black) using the option `--line-length 79`.
-Any pull requests that do no conform to this should be rejected by the CI.
+Project should be configured to block merging on pull requests that do not conform to these standards.
 
 ## Testing
 


### PR DESCRIPTION
A small proposal for a document outlining our practices on writing **Python** code.

What do you think about the Testing & Documentation blocks?