### PR TITLE
Fix typos on html code standards

### DIFF
--- a/coding/html.md
+++ b/coding/html.md
@@ -12,7 +12,7 @@ General rules for all HTML documents are:
 
  - HTML documents should use HTML5 doctype - `<!DOCTYPE html>`
  - Indent using 2 spaces
- - Tags and attributes should be lowercase (`<p class="intro">` not `<P CLASS="intro"`)
+ - Tags and attributes should be lowercase (`<p class="intro">` not `<P CLASS="intro">`)
  - Use double quotes for attribute values
  - Close all elements - either a closing tag (`<p>...</p>`) or self-closing (`<img src="jeff.jpg" />`)
 

--- a/coding/html.md
+++ b/coding/html.md
@@ -10,7 +10,7 @@ This document outlines the rules for writing HTML documents and fragments across
 We write HTML5 markup, following XHTML standards for readability.
 General rules for all HTML documents are:
 
- - HTML documents should use HTML5 doctype - `<!DOCTYPE html>`
+ - HTML documents should use HTML5 `doctype` - `<!DOCTYPE html>`
  - Indent using 2 spaces
  - Tags and attributes should be lowercase (`<p class="intro">` not `<P CLASS="intro">`)
  - Use double quotes for attribute values
@@ -18,5 +18,5 @@ General rules for all HTML documents are:
 
 ## Images
 
-  - Use alt attributes on img elements
-  - Use null alt text (`alt=""`) and no title attribute on img elements for images that Assistive Technology should ignore
+  - Use `alt` attributes on `img` elements
+  - Use null `alt` text (`alt=""`) and no `title` attribute on `img` elements for images that Assistive Technology should ignore


### PR DESCRIPTION
Hello, I found a typo on HTML code standards page as described on the first commit message. 

Also, I propose some changes for HTML literals on the page. I think it would be easier to read if HTML literals is styled as inline code. Just like code literals on other pages like JavaScript, Python and Stylesheet code standards