### PR TITLE
Remove duplicate 'Code Review' heading

### DIFF
--- a/coding/review.md
+++ b/coding/review.md
@@ -1,5 +1,3 @@
-# Code Review
-
 ## Etiquette
 
 ### Approval with suggestions for trivial changes


### PR DESCRIPTION
This 'heading' already appears in the site header. See https://cl.ly/846760cab770