### PR TITLE
Add note about build tools to javascript doc.

### DIFF
--- a/coding/javascript.md
+++ b/coding/javascript.md
@@ -30,6 +30,7 @@ e.g. `<a data-js="index-link" href="/index">Index</a>`.
 ## Tooling
 
 ### Build tools
+
 [Webpack](https://webpack.js.org/) is the preferred build tool for applications, and [Rollup](https://rollupjs.org/guide/en) is preferred for libraries.
 
 Rollup and Webpack for the most part have feature parity, so this is mostly a matter of taste and convenience, given Rollup is easier to configure for library builds.

--- a/coding/javascript.md
+++ b/coding/javascript.md
@@ -30,10 +30,9 @@ e.g. `<a data-js="index-link" href="/index">Index</a>`.
 ## Tooling
 
 ### Build tools
-[Webpack](https://webpack.js.org/) is the preferred build tool for applications, and [Rollup](https://rollupjs.org/guide/en) has generally been preferred for building
-cross environment libraries (both the browser and ESM/CJS environments) if the library in question uses ES6 modules. Rollup and Webpack for the most part have
-feature parity now however (Webpack has support for scope hoisting, and Rollup supports code splitting), so this is mostly a matter of taste and
-convenience, given Rollup is easier to configure for library builds.
+[Webpack](https://webpack.js.org/) is the preferred build tool for applications, and [Rollup](https://rollupjs.org/guide/en) is preferred for libraries.
+
+Rollup and Webpack for the most part have feature parity (Webpack has support for scope hoisting, and Rollup supports code splitting), so this is mostly a matter of taste and convenience, given Rollup is easier to configure for library builds.
 
 ### Dependency management
 

--- a/coding/javascript.md
+++ b/coding/javascript.md
@@ -32,7 +32,7 @@ e.g. `<a data-js="index-link" href="/index">Index</a>`.
 ### Build tools
 [Webpack](https://webpack.js.org/) is the preferred build tool for applications, and [Rollup](https://rollupjs.org/guide/en) has generally been preferred for building
 cross environment libraries (both the browser and ESM/CJS environments) if the library in question uses ES6 modules. Rollup and Webpack for the most part have
-feature parity now however (Webpack now has support for scope hoisting, and Rollup now supports code splitting), so this is mostly now a matter of taste and
+feature parity now however (Webpack has support for scope hoisting, and Rollup supports code splitting), so this is mostly a matter of taste and
 convenience, given Rollup is easier to configure for library builds.
 
 ### Dependency management

--- a/coding/javascript.md
+++ b/coding/javascript.md
@@ -31,7 +31,7 @@ e.g. `<a data-js="index-link" href="/index">Index</a>`.
 
 ### Build tools
 [Webpack](https://webpack.js.org/) is the preferred build tool for applications, and [Rollup](https://rollupjs.org/guide/en) has generally been preferred for building
-cross environment libraries (both the browser and ES modules environments) if the library in question uses ES6 modules. Rollup and Webpack for the most part have
+cross environment libraries (both the browser and ESM/CJS environments) if the library in question uses ES6 modules. Rollup and Webpack for the most part have
 feature parity now however (Webpack now has support for scope hoisting, and Rollup now supports code splitting), so this is mostly now a matter of taste and
 convenience, given Rollup is easier to configure for library builds.
 

--- a/coding/javascript.md
+++ b/coding/javascript.md
@@ -32,7 +32,7 @@ e.g. `<a data-js="index-link" href="/index">Index</a>`.
 ### Build tools
 [Webpack](https://webpack.js.org/) is the preferred build tool for applications, and [Rollup](https://rollupjs.org/guide/en) is preferred for libraries.
 
-Rollup and Webpack for the most part have feature parity (Webpack has support for scope hoisting, and Rollup supports code splitting), so this is mostly a matter of taste and convenience, given Rollup is easier to configure for library builds.
+Rollup and Webpack for the most part have feature parity, so this is mostly a matter of taste and convenience, given Rollup is easier to configure for library builds.
 
 ### Dependency management
 

--- a/coding/javascript.md
+++ b/coding/javascript.md
@@ -29,6 +29,12 @@ e.g. `<a data-js="index-link" href="/index">Index</a>`.
 
 ## Tooling
 
+### Build tools
+[Webpack](https://webpack.js.org/) is the preferred build tool for applications, and [Rollup](https://rollupjs.org/guide/en) has generally been preferred for building
+cross environment libraries (both the browser and ES modules environments) if the library in question uses ES6 modules. Rollup and Webpack for the most part have
+feature parity now however (Webpack now has support for scope hoisting, and Rollup now supports code splitting), so this is mostly now a matter of taste and
+convenience, given Rollup is easier to configure for library builds.
+
 ### Dependency management
 
 We use [Yarn](https://yarnpkg.com/en) for dependency management.


### PR DESCRIPTION
Rollup has generally been considered the standard tool for building libraries in the js community, largely in part to its ability to produce more efficient builds due to [scope hoisting](https://medium.com/adobetech/optimizing-javascript-through-scope-hoisting-2259ef7f5994). 

Webpack however has [supported](https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b) scope hoisting via the [ModuleConcatenationPlugin](https://webpack.js.org/plugins/module-concatenation-plugin/) which is the default for production mode builds since v3. This possibly removes one of the more compelling reasons to use Rollup.

The only potential argument for continuing to use Rollup for library builds is that it is generally easier to configure. Whether this incurs additional cognitive overhead, or actually makes things easier for us is probably something the team should discuss. While I'm not opposed to us using both tools, as an experiment, perhaps we should try to configure a similar Webpack build for one of our projects currently using Rollup.