### PR TITLE
Updates merging rule to be less strict on merging from original author

### DIFF
--- a/workflow/github.md
+++ b/workflow/github.md
@@ -82,7 +82,7 @@ Here are the steps that need to be completed before merging:
 - Your pull request must be approved by at least one person
 - Any automated checks must have passed
 - The original author should merge a pull request
-  - This can be overruled when necessary, only if the author is unavailable
+  - This can be overruled when necessary, f.e. if all looks good and the changes are needed for further development and the author is AFK.
   - Special care should be taken to ensure there have been no further changes requested
 
 ## Templates

--- a/workflow/github.md
+++ b/workflow/github.md
@@ -82,7 +82,7 @@ Here are the steps that need to be completed before merging:
 - Your pull request must be approved by at least one person
 - Any automated checks must have passed
 - The original author should merge a pull request
-  - This can be overruled when necessary, f.e. if all looks good and the changes are needed for further development and the author is AFK.
+  - This can be overruled when necessary, for example if all looks good and the changes are needed for further development and the author is AFK.
   - Special care should be taken to ensure there have been no further changes requested
 
 ## Templates


### PR DESCRIPTION
As discussed in the dev catchup it should be possible to merge a PR when everything looks good, even if you are not the original author.

Branch cleanup will be done in the Fork.